### PR TITLE
Added translation service and unit and mocking tests

### DIFF
--- a/.github/workflows/f24_codebb-translator-service.yml
+++ b/.github/workflows/f24_codebb-translator-service.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python version
         uses: actions/setup-python@v1
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Create and start virtual environment
         run: |
@@ -28,9 +28,22 @@ jobs:
           source venv/bin/activate
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -r requirements.txt
 
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest
+
       - name: Zip artifact for deployment
         run: zip release.zip ./* -r
 
@@ -46,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'Production'
+      name: "Production"
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
@@ -58,10 +71,12 @@ jobs:
       - name: Unzip artifact for deployment
         run: unzip release.zip
 
-      - name: 'Deploy to Azure Web App'
+      - name: "Deploy to Azure Web App"
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
         with:
-          app-name: 'codebb-translator-service'
-          slot-name: 'Production'
+          app-name: "codebb-translator-service"
+          slot-name: "Production"
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B33821D2E244498D89B42AB7C27429D4 }}

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,7 @@ venv/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+dump.rdb
+.python-version
+.app

--- a/app.py
+++ b/app.py
@@ -2,14 +2,15 @@ import os
 
 from flask import Flask
 from flask import request, jsonify
-from src.translator import translate_content
+from src.translator import translate_content, query_llm_robust
 
 app = Flask(__name__)
 
 @app.route("/")
 def translator():
     content = request.args.get("content", default = "", type = str)
-    is_english, translated_content = translate_content(content)
+    is_english, translated_content = query_llm_robust(content)
+    # is_english, translated_content = translate_content(content)
     return jsonify({
         "is_english": is_english,
         "translated_content": translated_content,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 Flask==3.0.0
 pytest==7.4.0
+openai==1.54.3
+pytest==7.4.0
+ipytest==0.14.2
+pytest-mock==3.14.0
+mock==5.1.0
+sentence-transformers==3.3.0

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,34 +1,165 @@
-def translate_content(content: str) -> tuple[bool, str]:
-    if content == "这是一条中文消息":
-        return False, "This is a Chinese message"
-    if content == "Ceci est un message en français":
-        return False, "This is a French message"
-    if content == "Esta es un mensaje en español":
-        return False, "This is a Spanish message"
-    if content == "Esta é uma mensagem em português":
-        return False, "This is a Portuguese message"
-    if content  == "これは日本語のメッセージです":
-        return False, "This is a Japanese message"
-    if content == "이것은 한국어 메시지입니다":
-        return False, "This is a Korean message"
-    if content == "Dies ist eine Nachricht auf Deutsch":
-        return False, "This is a German message"
-    if content == "Questo è un messaggio in italiano":
-        return False, "This is an Italian message"
-    if content == "Это сообщение на русском":
-        return False, "This is a Russian message"
-    if content == "هذه رسالة باللغة العربية":
-        return False, "This is an Arabic message"
-    if content == "यह हिंदी में संदेश है":
-        return False, "This is a Hindi message"
-    if content == "นี่คือข้อความภาษาไทย":
-        return False, "This is a Thai message"
-    if content == "Bu bir Türkçe mesajdır":
-        return False, "This is a Turkish message"
-    if content == "Đây là một tin nhắn bằng tiếng Việt":
-        return False, "This is a Vietnamese message"
-    if content == "Esto es un mensaje en catalán":
-        return False, "This is a Catalan message"
-    if content == "This is an English message":
-        return True, "This is an English message"
-    return True, content
+# def translate_content(content: str) -> tuple[bool, str]:
+#     if content == "这是一条中文消息":
+#         return False, "This is a Chinese message"
+#     if content == "Ceci est un message en français":
+#         return False, "This is a French message"
+#     if content == "Esta es un mensaje en español":
+#         return False, "This is a Spanish message"
+#     if content == "Esta é uma mensagem em português":
+#         return False, "This is a Portuguese message"
+#     if content  == "これは日本語のメッセージです":
+#         return False, "This is a Japanese message"
+#     if content == "이것은 한국어 메시지입니다":
+#         return False, "This is a Korean message"
+#     if content == "Dies ist eine Nachricht auf Deutsch":
+#         return False, "This is a German message"
+#     if content == "Questo è un messaggio in italiano":
+#         return False, "This is an Italian message"
+#     if content == "Это сообщение на русском":
+#         return False, "This is a Russian message"
+#     if content == "هذه رسالة باللغة العربية":
+#         return False, "This is an Arabic message"
+#     if content == "यह हिंदी में संदेश है":
+#         return False, "This is a Hindi message"
+#     if content == "นี่คือข้อความภาษาไทย":
+#         return False, "This is a Thai message"
+#     if content == "Bu bir Türkçe mesajdır":
+#         return False, "This is a Turkish message"
+#     if content == "Đây là một tin nhắn bằng tiếng Việt":
+#         return False, "This is a Vietnamese message"
+#     if content == "Esto es un mensaje en catalán":
+#         return False, "This is a Catalan message"
+#     if content == "This is an English message":
+#         return True, "This is an English message"
+#     return True, content
+
+from openai import AzureOpenAI
+import json
+import os
+
+# Initialize the Azure OpenAI client
+client = AzureOpenAI(
+    api_key=os.getenv('OPEN_AI_API_KEY'), 
+    api_version="2024-02-15-preview",
+    azure_endpoint="https://codebb-ai.openai.azure.com/"  # Replace with your Azure endpoint
+)
+
+def validate_translation_response(response: str):
+    """
+    Validates the translation response format.
+    Expected format: {"translation": "translated_text"}
+    """
+    try:
+        data = json.loads(response)
+        if not isinstance(data, dict) or "translation" not in data:
+            raise Exception("Invalid translation response format")
+        translation = str(data["translation"]).strip()
+        if not translation:
+            raise Exception("Empty translation")
+        return translation
+    except json.JSONDecodeError:
+        raise Exception("Invalid JSON in translation response")
+    except Exception as e:
+        raise Exception(f"Unexpected error in translation validation: {str(e)}")
+
+def get_translation(post: str) -> str:
+  try:
+    context = "Translate the following text into clear and natural English, preserving the original meaning, nuances, and context as directly as possible. Use everyday English terms that sound natural to a native English speaker. Ensure proper grammar, idioms, and cultural context. If a phrase or expression doesn’t translate directly, adapt it to maintain the intended tone and sentiment. Return with JSON in the format: {\"translation\": \"translated_text\"}.  If the text is unintelligible or malformed, return an empty JSON object"
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",  # This should match your deployment name in Azure
+
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a translation expert tasked with translating text into clear and natural English, as accurately and directly as possible. Respond with JSON in the format: {\"translation\": \"translated_text\"}.  If the text is unintelligible or malformed, return an empty JSON object"
+            },
+            {
+                "role": "user",
+                "content": context + f"Text to translate: {post}"
+            }
+        ],
+        response_format={"type": "json_object"}
+    )
+    return validate_translation_response(response.choices[0].message.content)
+  except Exception as e:
+    return ""
+  
+def validate_language_response(response: str):
+    """
+    Validates the language detection response format.
+    Expected format: {"language": "detected_language"}
+    """
+    try:
+        data = json.loads(response)
+        if not isinstance(data, dict) or "language" not in data:
+            raise Exception("Invalid language response format")
+        language = str(data["language"]).strip()
+        if not language:
+            raise Exception("Empty language detected")
+        return language
+    except json.JSONDecodeError:
+        raise Exception("Invalid JSON in language response")
+    except Exception as e:
+        raise Exception(f"Unexpected error in language validation: {str(e)}")
+
+def get_language(post: str) -> str:
+    try:
+      context = "Identify the language of the following text without translating it. Return only the name of the language in JSON with format: {\"language\": \"detected_language\"}. If the text is unintelligible or malformed, return an empty JSON object\n"
+      response = client.chat.completions.create(
+          model="gpt-4o-mini",  # This should match your deployment name in Azure
+          messages=[
+              {
+                  "role": "system",
+                  "content": "You are a translation expert tasked with identifying the language that a piece of text is written in, providing only the name of the language in English. Respond in JSON with format: {\"language\": \"detected_language\"}"
+              },
+              {
+                  "role": "user",
+                  "content": context + f"Text: {post}"
+              }
+          ],
+          response_format={"type": "json_object"}
+      )
+      return validate_language_response(response.choices[0].message.content)
+    except Exception as e:
+      return ""
+
+def query_llm_robust(post: str) -> tuple[bool, str]:
+    try:
+        # Input validation
+        if not post or not isinstance(post, str):
+            return False, "Error: Unintelligible/malformed post or translation failure."
+
+        # Get language with retry
+        language = None
+        for attempt in range(2):  # Try twice
+            language = get_language(post)
+            if language:
+                break
+
+        if not language:
+            return False, "Error: Unintelligible/malformed post or translation failure."
+
+        # If English, return original text
+        if language.lower() == "english":
+            return True, post
+
+        # Get translation with retry
+        translation = None
+        for attempt in range(2):  # Try twice in case it fails the first time unexpectedly
+            translation = get_translation(post)
+            if translation:
+                break
+
+        if not translation:
+            return False, "Error: Unintelligible/malformed post or translation failure."
+
+        return False, translation
+
+    except Exception as e:
+        print(f"Unexpected error in query_llm_robust: {str(e)}")
+        return False, "Error: Unintelligible/malformed post or translation failure."
+    
+
+print(get_translation("Hier ist dein erstes Beispiel."))
+print(get_language("Hier ist dein erstes Beispiel."))

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,13 +1,184 @@
-from src.translator import translate_content
+from src.translator import query_llm_robust, client
+from unittest.mock import patch
+import json
+from sentence_transformers import SentenceTransformer, util
+model = SentenceTransformer('all-MiniLM-L6-v2')
 
+def eval_single_response_translation(expected_answer: str, llm_response: str) -> float:
+  # Compute embeddings for both expected answer and LLM response
+  embeddings_expected = model.encode(expected_answer, convert_to_tensor=True)
+  embeddings_response = model.encode(llm_response, convert_to_tensor=True)
+
+  # Calculate cosine similarity between embeddings
+  similarity_score = util.cos_sim(embeddings_expected, embeddings_response).item()
+  return similarity_score
+
+def is_valid_translation(expected_answer: str, llm_response: str) -> bool:
+    similarity_score = eval_single_response_translation(expected_answer, llm_response)
+    return similarity_score > 0.9
 
 def test_chinese():
-    is_english, translated_content = translate_content("这是一条中文消息")
+    is_english, translated_content = query_llm_robust("这是一条中文消息")
     assert is_english == False
-    assert translated_content == "This is a Chinese message"
+    assert is_valid_translation("This is a Chinese message.", translated_content)
 
-def test_llm_normal_response():
-    pass
+def test_english_example_1():
+    is_english, translated_content = query_llm_robust("This is an example sentence in English.")
+    assert is_english == True
+    assert is_valid_translation("This is an example sentence in English.", translated_content)
 
-def test_llm_gibberish_response():
-    pass
+def test_english_example_2():
+    is_english, translated_content = query_llm_robust("Learning new skills is always rewarding.")
+    assert is_english == True
+    assert is_valid_translation("Learning new skills is always rewarding.", translated_content)
+
+def test_english_example_3():
+    is_english, translated_content = query_llm_robust("Can you help me understand this concept?")
+    assert is_english == True
+    assert is_valid_translation("Can you help me understand this concept?", translated_content)
+
+def test_english_example_4():
+    is_english, translated_content = query_llm_robust("It's a beautiful day outside.")
+    assert is_english == True
+    assert is_valid_translation("It's a beautiful day outside.", translated_content)
+
+def test_english_example_5():
+    is_english, translated_content = query_llm_robust("What time does the event start?")
+    assert is_english == True
+    assert is_valid_translation("What time does the event start?", translated_content)
+
+def test_spanish_example():
+    is_english, translated_content = query_llm_robust("Este es un ejemplo en español.")
+    assert is_english == False
+    assert is_valid_translation("This is an example in Spanish.", translated_content)
+
+def test_french_example():
+    is_english, translated_content = query_llm_robust("Ceci est une phrase en français.")
+    assert is_english == False
+    assert is_valid_translation("This is a sentence in French.", translated_content)
+
+def test_japanese_example():
+    is_english, translated_content = query_llm_robust("今日は良い天気ですね。")
+    assert is_english == False
+    assert is_valid_translation("The weather is nice today.", translated_content)
+
+def test_german_example():
+    is_english, translated_content = query_llm_robust("Wie geht es dir heute?")
+    assert is_english == False
+    assert is_valid_translation("How are you today?", translated_content)
+
+def test_russian_example():
+    is_english, translated_content = query_llm_robust("Это прекрасный день для прогулки.")
+    assert is_english == False
+    assert is_valid_translation("It is a beautiful day for a walk.", translated_content)
+
+def test_unintelligible_example_1():
+    is_english, translated_content = query_llm_robust("asldkfjasdf!")
+    assert is_english == False
+    assert is_valid_translation("Error: Unintelligible/malformed post or translation failure.", translated_content)
+
+def test_unintelligible_example_2():
+    is_english, translated_content = query_llm_robust("23lkj4nvlwe")
+    assert is_english == False
+    assert is_valid_translation("Error: Unintelligible/malformed post or translation failure.", translated_content)
+
+def test_unintelligible_example_3():
+    is_english, translated_content = query_llm_robust("##@!!weroie")
+    assert is_english == False
+    assert is_valid_translation("Error: Unintelligible/malformed post or translation failure.", translated_content)
+
+def test_unintelligible_example_4():
+    is_english, translated_content = query_llm_robust("blargl fzz#")
+    assert is_english == False
+    assert is_valid_translation("Error: Unintelligible/malformed post or translation failure.", translated_content)
+
+def test_unintelligible_example_5():
+    is_english, translated_content = query_llm_robust("wkejfw@#2309")
+    assert is_english == False
+    assert is_valid_translation("Error: Unintelligible/malformed post or translation failure.", translated_content)
+
+@patch.object(client.chat.completions, 'create')
+def test_unexpected_language(mocker):
+    # we mock the model's response to return a random non-JSON message
+    mocker.return_value.choices[0].message.content = "I don't understand your request"
+
+    assert query_llm_robust("Hier ist dein erstes Beispiel.") == (False, "Error: Unintelligible/malformed post or translation failure.")
+
+@patch.object(client.chat.completions, 'create')
+def test_english_input(mocker):
+    """Test that English input is returned as-is"""
+    # Mock language detection to return English in JSON format
+    mocker.side_effect = [
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"language": "english"})})()})()]})(),
+    ]
+
+    result = query_llm_robust("This is an English sentence.")
+    assert result == (True, "This is an English sentence.")
+
+@patch.object(client.chat.completions, 'create')
+def test_successful_translation(mocker):
+    """Test successful translation from German to English"""
+    # Mock language detection to return German, then translation in JSON format
+    mocker.side_effect = [
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"language": "german"})})()})()]})(),
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"translation": "This is your first example."})})()})()]})()
+    ]
+
+    result = query_llm_robust("Hier ist dein erstes Beispiel.")
+    assert result == (False, "This is your first example.")
+
+@patch.object(client.chat.completions, 'create')
+def test_empty_input(mocker):
+    """Test handling of empty input"""
+    result = query_llm_robust("")
+    assert result == (False, "Error: Unintelligible/malformed post or translation failure.")
+
+    result = query_llm_robust(None)
+    assert result == (False, "Error: Unintelligible/malformed post or translation failure.")
+
+@patch.object(client.chat.completions, 'create')
+def test_failed_language_detection(mocker):
+    """Test handling of failed language detection"""
+    # Mock language detection to return empty JSON responses twice
+    mocker.side_effect = [
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"language": ""})})()})()]})(),
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"language": ""})})()})()]})()
+    ]
+
+    result = query_llm_robust("こんにちは")
+    assert result == (False, "Error: Unintelligible/malformed post or translation failure.")
+
+@patch.object(client.chat.completions, 'create')
+def test_failed_translation(mocker):
+    """Test handling of failed translation"""
+    # Mock successful language detection but failed translation with JSON
+    mocker.side_effect = [
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"language": "japanese"})})()})()]})(),
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"translation": ""})})()})()]})(),
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"translation": ""})})()})()]})()
+    ]
+
+    result = query_llm_robust("こんにちは")
+    assert result == (False, "Error: Unintelligible/malformed post or translation failure.")
+
+@patch.object(client.chat.completions, 'create')
+def test_malformed_json_response(mocker):
+    """Test handling of malformed JSON response"""
+    # Mock language detection to return invalid JSON
+    mocker.side_effect = [
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': '{"language": "german"'})()})()]})()
+    ]
+
+    result = query_llm_robust("Hallo Welt")
+    assert result == (False, "Error: Unintelligible/malformed post or translation failure.")
+
+@patch.object(client.chat.completions, 'create')
+def test_misnamed_json_field_response(mocker):
+    """Test handling of misnamed fields in JSON response"""
+    # Mock language detection to return invalid JSON
+    mocker.side_effect = [
+        type('obj', (), {'choices': [type('obj', (), {'message': type('obj', (), {'content': json.dumps({"name": "german"})})()})()]})()
+    ]
+
+    result = query_llm_robust("Hallo Welt")
+    assert result == (False, "Error: Unintelligible/malformed post or translation failure.")


### PR DESCRIPTION
# What
1. Removed hardcoded translation service endpoint, and added actual llm querying.
2. Added unit test cases for the translation service
3. Added mocker test cases for the translation service
4. Modified the azure deployment flow to run tests, linting, and environment variable setting.

# Why
Modularizing the translation service by having it separate from the nodebb database so that it can be treated as a microservice rather than a monolith.

This creates an endpoint at [codebb-translator-service.azurewebsites.net](codebb-translator-service.azurewebsites.net) that translates the content sent directly to the endpoint. 

Testing ensures the LLM responses are at least 90% accurate and uses mocking to ensure that malformed inputs do not crash the server and are handled properly.

# How
Added query_llm_robust from experiment notebook that detects language, translates the post, and reports errors if they occur. This is created in `src/translator.py`. 

Added unit and mocker test cases in `test/unit/test_translator.py`, with 18 unit tests to verify functionality across multiple languages, English, and malformed inputs, as well as 6 robust mocker tests that add malformed JSON responses.

Modified `.github/workflows/f24_codebb-translator-service.yml` to deploy to Azure with requirements installed.

# Screenshots
Default endpoint response:
<img width="831" alt="image" src="https://github.com/user-attachments/assets/2d1c920a-e584-41c4-adb8-770aebb759bb">

Translating a German sentence:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/c7b3ed3a-2587-4f22-9417-deaaa00752f3">
