### PR TITLE
Moving environment loading step in workflow

### DIFF
--- a/.github/workflows/f24_codebb-translator-service.yml
+++ b/.github/workflows/f24_codebb-translator-service.yml
@@ -10,6 +10,9 @@ on:
       - f24
   workflow_dispatch:
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -68,8 +71,6 @@ jobs:
       - name: "Deploy to Azure Web App"
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
         with:
           app-name: "codebb-translator-service"
           slot-name: "Production"


### PR DESCRIPTION
# What
Load the environment key before deploying the azure app, as this is required to run the tests and to actually use the AI Azure service in deployment.

# Why
Without the environment key loaded, the tests cannot run, so the key must be added before the tests are initialized.

# How
Adjusted the translator-service.yml accordingly by moving the environment key setting to line 13.