### PR TITLE
Changing key name

### DIFF
--- a/.github/workflows/f24_codebb-translator-service.yml
+++ b/.github/workflows/f24_codebb-translator-service.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  OPENAI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
+  AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
 
 jobs:
   build:

--- a/src/translator.py
+++ b/src/translator.py
@@ -39,7 +39,7 @@ import os
 
 # Initialize the Azure OpenAI client
 client = AzureOpenAI(
-    api_key=os.getenv('OPEN_AI_API_KEY'), 
+    api_key=os.getenv('AZURE_OPENAI_API_KEY'), 
     api_version="2024-02-15-preview",
     azure_endpoint="https://codebb-ai.openai.azure.com/"  # Replace with your Azure endpoint
 )


### PR DESCRIPTION
# What
Changing open ai key name from OPEN_AI_API_KEY TO AZURE_OPENAI_API_KEY.

# Why
Deployment wasn't working since the key name did not match the required name in the Azure deployment and the Azure LLM service.

# How
Changing open ai key name from OPEN_AI_API_KEY TO AZURE_OPENAI_API_KEY.